### PR TITLE
cli: fix bug when generating key pairs.

### DIFF
--- a/cmd/minisign/minisign.go
+++ b/cmd/minisign/minisign.go
@@ -136,8 +136,8 @@ func generateKeyPair(secKeyFile, pubKeyFile string, force bool) {
 
 	fmt.Print("Please enter a password to protect the secret key.\n\n")
 	var (
-		password      = readPassword(os.Stdin, "Password: ")
-		passwordAgain = readPassword(os.Stdin, "Password (one more time): ")
+		password      = readPassword(os.Stdin, "Enter Password: ")
+		passwordAgain = readPassword(os.Stdin, "Enter Password (one more time): ")
 	)
 	if password != passwordAgain {
 		log.Fatal("Error: passwords don't match")
@@ -157,7 +157,7 @@ func generateKeyPair(secKeyFile, pubKeyFile string, force bool) {
 
 	var fileFlags = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
 	if !force {
-		fileFlags = os.O_EXCL // fail if the file already exists
+		fileFlags |= os.O_EXCL // fail if the file already exists
 	}
 	skFile, err := os.OpenFile(secKeyFile, fileFlags, 0600)
 	if err != nil {


### PR DESCRIPTION
This commit fixes a file creation bug in
the key generation code. If the force
flag has not been specified the OS file
flags would only contain `O_EXCL` such that
creation attempts will fail.

Now, the code *additionally* sets the `O_EXCL`
flag but preserves all other flags - i.e. `O_CREATE`.