### PR TITLE
trim carriage-return at the end of signature comments

### DIFF
--- a/internal/testdata/robtest.ps1.minisig
+++ b/internal/testdata/robtest.ps1.minisig
@@ -1,0 +1,4 @@
+untrusted comment: signature from minisign secret key
+RWQ3ly9IPenQ6XE4gvV0tpJPSRdw/Si+Q4r97LbpLj0Hb3sV+XFydynJg3iFT2PjIlE3xViNOmFT9XrIoidedDr41+Ly0AYbUQg=
+trusted comment: timestamp:1617721023	file:robtest.ps1
+HkxuqHSvipJo/unNKgDS+JGDB0+Q5d8nOeoJ0NGOnKBNsNdvAj8FWf7fhaPV7mzRJ1ooLvYpI0yUsD7lpaDwBQ==

--- a/signature.go
+++ b/signature.go
@@ -141,9 +141,9 @@ func (s *Signature) UnmarshalText(text []byte) error {
 	}
 
 	var (
-		untrustedComment        = segments[0]
+		untrustedComment        = strings.TrimRight(segments[0], "\r")
 		encodedSignature        = segments[1]
-		trustedComment          = segments[2]
+		trustedComment          = strings.TrimRight(segments[2], "\r")
 		encodedCommentSignature = segments[3]
 	)
 	if !strings.HasPrefix(untrustedComment, "untrusted comment: ") {

--- a/signature_test.go
+++ b/signature_test.go
@@ -4,7 +4,10 @@
 
 package minisign
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestEqualSignature(t *testing.T) {
 	for i, test := range equalSignatureTests {
@@ -61,6 +64,19 @@ func TestUnmarshalSignature(t *testing.T) {
 				t.Fatalf("Test %d: untrusted comment mismatch: got '%s' - want '%s'", i, signature.UntrustedComment, test.Signature.UntrustedComment)
 			}
 		}
+	}
+}
+
+func TestSignatureCarriageReturn(t *testing.T) {
+	signature, err := SignatureFromFile("./internal/testdata/robtest.ps1.minisig")
+	if err != nil {
+		t.Fatalf("Failed to read signature from file: %v", err)
+	}
+	if strings.HasSuffix(signature.UntrustedComment, "\r") {
+		t.Fatal("Untrusted comment ends with a carriage return")
+	}
+	if strings.HasSuffix(signature.TrustedComment, "\r") {
+		t.Fatal("Trusted comment ends with a carriage return")
 	}
 }
 


### PR DESCRIPTION
This commit fixes a bug when parsing minisign signatures.
Before, any carriage return ('\r') at the end of a
trusted / untrusted comment was not removed. This lead to
signature verification failures. In particular, the verification
of the comment signature fails when e.g. the OS uses `\r\n` for
newlines instead of `\n`.

Byte representation of a trusted comment - with and without the
trailing carriage return.
```
[116 105 109 101 115 116 97 109 112 58 49 54 49 55 55 50 49 48 50 51 9 102 105 108 101 58 114 111 98 116 101 115 116 46 112 115 49 13]
[116 105 109 101 115 116 97 109 112 58 49 54 49 55 55 50 49 48 50 51 9 102 105 108 101 58 114 111 98 116 101 115 116 46 112 115 49]
```

Fixes #7