### PR TITLE
document that secret/public key args are optional for -G/-R

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ This is a Go implementation of the [original C implementation](https://github.co
 
 ```
 Usage:
-    minisign -G -p <pubKey> -s <secKey>
+    minisign -G [-p <pubKey>] [-s <secKey>]
     minisign -S [-H] [-x <signature>] [-s <secKey>] [-c <comment>] [-t <comment>] -m <file>...
     minisign -V [-x <signature>] [-p <pubKey> | -P <pubKey>] [-o] [-q | -Q ] -m <file>
-    minisign -R -s <secKey> -p <pubKey>
+    minisign -R [-s <secKey>] [-p <pubKey>]
  
 Options:
     -G               Generate a new public/secret key pair.       

--- a/cmd/minisign/minisign.go
+++ b/cmd/minisign/minisign.go
@@ -23,10 +23,10 @@ import (
 )
 
 const usage = `Usage:
-    minisign -G -p <pubKey> -s <secKey>
+    minisign -G [-p <pubKey>] [-s <secKey>]
     minisign -S [-H] [-x <signature>] [-s <secKey>] [-c <comment>] [-t <comment>] -m <file>...
     minisign -V [-x <signature>] [-p <pubKey> | -P <pubKey>] [-o] [-q | -Q ] -m <file>
-    minisign -R -s <secKey> -p <pubKey>
+    minisign -R [-s <secKey>] [-p <pubKey>]
  
 Options:
     -G               Generate a new public/secret key pair.       


### PR DESCRIPTION
This commit improves the `minisign -h` output
by documenting that the secret/public key arguments
are optional for key generation / reconstruction.