### PR TITLE
update CI to Go 1.17 and golang-ci to 1.42

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.16.x, 1.17.x]
     steps:
     - name: Set up Go ${{ matrix.go-version }}
       uses: actions/setup-go@v1
@@ -29,7 +29,7 @@ jobs:
       env:
         GO111MODULE: on
       run: |
-         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.33.0
+         curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.42.0
          $(go env GOPATH)/bin/golangci-lint run --config ./.golangci.yml
          go vet ./...
   test:
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go-version: [1.16.x]
+        go-version: [1.17.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - name: Set up Go ${{ matrix.go-version }} on ${{ matrix.os }}


### PR DESCRIPTION
This commit updates the CI to build using
Go 1.16.x and 1.17.x. CI tests are now run
using Go 1.17.x.

Further, this commit updates CI linting to
golangci-lint 1.42