### PR TITLE
Make minisign buildable as a nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1672844754,
+        "narHash": "sha256-o26WabuHABQsaHxxmIrR3AQRqDFUEdLckLXkVCpIjSU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9ade2c8240e00a4784fac282a502efff2786bdc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,22 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+    in {
+      packages = {
+        default = pkgs.buildGoModule {
+          pname = "minisign";
+          version = if self ? shortRev && self ? revCount # available only when building a clean tree
+            then "${self.lastModifiedDate}.${self.shortRev}.${builtins.toString self.revCount}"
+            else self.lastModifiedDate;
+          src = self;
+          # this hash will need to change when go.mod is updated
+          vendorHash = "sha256-CM9aw6Hyt2aaf5CwWcd4q4pVm9QSqV/HClhRkCRQtN8=";
+        };
+      };
+    });
+}


### PR DESCRIPTION
With this merged, users with the [Nix](https://nixos.org/) package manager installed will be able to run `nix run github:aead/minisign# -- ...arguments...` even if they don't have a Go compiler on their system.

Don't take this PR as any kind of forceful advocacy -- built it for my own purposes; if the maintenance load of needing to update `vendorHash` when go.mod changes isn't sensible, there'll be no hard feelings if this PR is closed unmerged.