### PR TITLE
Add trailing newline on signature output

### DIFF
--- a/signature.go
+++ b/signature.go
@@ -107,6 +107,8 @@ func (s Signature) String() string {
 	buffer.WriteByte('\n')
 
 	buffer.WriteString(base64.StdEncoding.EncodeToString(s.CommentSignature[:]))
+	buffer.WriteByte('\n')
+
 	return buffer.String()
 }
 


### PR DESCRIPTION
A minisign signature consists of lines of text.

On Windows, text files are newline-delimited: newlines are needed only to separate lines, and a line can be valid without a newline after it (should it be the last line in a file).

On UNIX, text files are newline-terminated: to be a fully legal text file, each line _including the last one_ is expected to have a trailing newline.

The upstream C minisign tool follows UNIX conventions for signature output in this respect. With this PR, the golang tool does likewise.